### PR TITLE
Allowing autoplay again

### DIFF
--- a/files/uzblmonitor
+++ b/files/uzblmonitor
@@ -136,6 +136,7 @@ class Chrome():
                 "/usr/bin/google-chrome-stable",
                 "--no-default-browser-check",
                 "--no-first-run",
+                "--autoplay-policy=no-user-gesture-required",
                 "--user-data-dir=%s" % user_data_dir,
                 "--app=%s" % insert_basic_auth(self.url),
             ] + userscript_args,


### PR DESCRIPTION
Since a policy change in Chrome, video autoplay doesn't work anymore by default
https://developers.google.com/web/updates/2017/09/autoplay-policy-changes

This review adds the right flag to make it behave like it once did.