### PR TITLE
For UHD resolution instead of 4k

### DIFF
--- a/files/xsession
+++ b/files/xsession
@@ -1,4 +1,6 @@
 #!/bin/bash
 xset -dpms
 xset s off
+# Force UHD (usually native panel resolution) instead of 4k
+xrandr --current |grep -q 'connected 4096x2160' && xrandr --output $(xrandr --current |grep 'connected 4096x2160' |cut -d ' ' -f1) --mode 3840x2160
 exec sleep infinity


### PR DESCRIPTION
Some TV will advertise 4k capability 4096x2160 while in fact their
native panel resolution is "only" UHD : 3840x2160